### PR TITLE
Improve input session name

### DIFF
--- a/Resources/EmojiIM.entitlements
+++ b/Resources/EmojiIM.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.temporary-exception.mach-register.global-name</key>
+	<string>jp.mzp.inputmethod.EmojiIM_Connection</string>
 </dict>
 </plist>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>InputMethodConnectionName</key>
-	<string>EmojiInputSession</string>
+	<string>jp.mzp.inputmethod.EmojiIM_Connection</string>
 	<key>InputMethodServerControllerClass</key>
 	<string>EmojiInputController</string>
 	<key>LSApplicationCategoryType</key>

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -18,7 +18,9 @@ internal class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         NSLog("EmojiIM launching: \(kBuiltDate)(\(kRevision))")
-        server = IMKServer(name: "EmojiInputSession", bundleIdentifier: Bundle.main.bundleIdentifier)
+        let bundle = Bundle.main
+        server = IMKServer(name: bundle.infoDictionary?["InputMethodConnectionName"] as? String,
+                           bundleIdentifier: bundle.bundleIdentifier)
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {


### PR DESCRIPTION
## 🚚 Change input method name
I investigated default input method (e.g. JapaneseIM), and found that it use unique prefix like:

```xml
        <key>InputMethodConnectionName</key>
        <string>com.apple.inputmethod.JIMx.IMK_Connection</string>
```

This is good protocol to avoid conflict with other IM.

So, I decide to use `jp.mzp.inputmethod` as prefix.

## 💄 Reduce duplicate / Add permission for session name
This is backport of #3.