### PR TITLE
Show candidate using IMKCandidates

### DIFF
--- a/EmojiIM.xcodeproj/project.pbxproj
+++ b/EmojiIM.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		130DC5DA1F65F91D00BBCB60 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 130DC5D81F65F91D00BBCB60 /* MainMenu.xib */; };
 		134922DF1F6B33AF000AA483 /* EmojiInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134922DE1F6B33AF000AA483 /* EmojiInputController.swift */; };
 		134A02F01F6B36C60050216F /* InputMethodIcon.tiff in Resources */ = {isa = PBXBuildFile; fileRef = 134922E01F6B33B9000AA483 /* InputMethodIcon.tiff */; };
+		136A4CCD1F904CA20020BDBE /* EmojiDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136A4CCC1F904CA20020BDBE /* EmojiDictionary.swift */; };
+		13AE25131F9052730073912E /* EmojiDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136A4CCC1F904CA20020BDBE /* EmojiDictionary.swift */; };
 		13B7E6621F6D6327008C528A /* BuildInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B7E6611F6D631F008C528A /* BuildInfo.swift */; };
 		13BE30431F731F7B001D3AF8 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13BE30421F731F7B001D3AF8 /* Tests.swift */; };
 		13BE305B1F7325C8001D3AF8 /* EmojiAutomaton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13BE305A1F7325BA001D3AF8 /* EmojiAutomaton.swift */; };
@@ -47,6 +49,7 @@
 		130DC5DC1F65F91D00BBCB60 /* EmojiIM.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = EmojiIM.entitlements; sourceTree = "<group>"; };
 		134922DE1F6B33AF000AA483 /* EmojiInputController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiInputController.swift; sourceTree = "<group>"; };
 		134922E01F6B33B9000AA483 /* InputMethodIcon.tiff */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = InputMethodIcon.tiff; sourceTree = "<group>"; };
+		136A4CCC1F904CA20020BDBE /* EmojiDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiDictionary.swift; sourceTree = "<group>"; };
 		13B7E6611F6D631F008C528A /* BuildInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildInfo.swift; sourceTree = "<group>"; };
 		13BE30401F731F7B001D3AF8 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		13BE30421F731F7B001D3AF8 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
@@ -124,9 +127,18 @@
 			children = (
 				130DC5D41F65F91D00BBCB60 /* AppDelegate.swift */,
 				13BE30541F73255D001D3AF8 /* Automaton */,
+				136A4CCB1F904C870020BDBE /* Dictionary */,
 				13BE304A1F73222F001D3AF8 /* InputMethodKit */,
 			);
 			path = Sources;
+			sourceTree = "<group>";
+		};
+		136A4CCB1F904C870020BDBE /* Dictionary */ = {
+			isa = PBXGroup;
+			children = (
+				136A4CCC1F904CA20020BDBE /* EmojiDictionary.swift */,
+			);
+			path = Dictionary;
 			sourceTree = "<group>";
 		};
 		13BE30411F731F7B001D3AF8 /* Tests */ = {
@@ -453,6 +465,7 @@
 			files = (
 				130DC5D51F65F91D00BBCB60 /* AppDelegate.swift in Sources */,
 				13BE305E1F7325CC001D3AF8 /* UserInput.swift in Sources */,
+				136A4CCD1F904CA20020BDBE /* EmojiDictionary.swift in Sources */,
 				13B7E6621F6D6327008C528A /* BuildInfo.swift in Sources */,
 				13BE305D1F7325CC001D3AF8 /* InputMethodState.swift in Sources */,
 				134922DF1F6B33AF000AA483 /* EmojiInputController.swift in Sources */,
@@ -467,6 +480,7 @@
 			files = (
 				13BE30431F731F7B001D3AF8 /* Tests.swift in Sources */,
 				13BE30601F7325CD001D3AF8 /* UserInput.swift in Sources */,
+				13AE25131F9052730073912E /* EmojiDictionary.swift in Sources */,
 				13BE305C1F7325C9001D3AF8 /* EmojiAutomaton.swift in Sources */,
 				13BE305F1F7325CD001D3AF8 /* InputMethodState.swift in Sources */,
 				13BE30651F73260E001D3AF8 /* AutomatonTest.swift in Sources */,

--- a/Sources/Automaton/EmojiAutomaton.swift
+++ b/Sources/Automaton/EmojiAutomaton.swift
@@ -15,6 +15,8 @@ public class EmojiAutomaton {
     private let observer: Signal<UserInput, NoError>.Observer
     let text: Signal<String, NoError>
     let markedText: Property<String>
+    let candidates: Property<[String]>
+
     private var handled: Bool = false
 
     init() {
@@ -22,6 +24,9 @@ public class EmojiAutomaton {
         self.text = text
         let markedTextProperty = MutableProperty<String>("")
         self.markedText = Property(markedTextProperty)
+
+        let candidatesProperty = MutableProperty<[String]>([])
+        self.candidates = Property(candidatesProperty)
 
         let mappings: [ActionMapping<InputMethodState, UserInput>] = [
             /*  Input <|> fromState => toState <|> action */

--- a/Sources/Automaton/EmojiAutomaton.swift
+++ b/Sources/Automaton/EmojiAutomaton.swift
@@ -26,8 +26,8 @@ public class EmojiAutomaton {
         let mappings: [ActionMapping<InputMethodState, UserInput>] = [
             /*  Input <|> fromState => toState <|> action */
             /* -------------------------------------------*/
-            UserInput.isInput <|> .normal => .composing <|> {
-                $0.ifInput { markedTextProperty.swap($0) }
+            .colon <|> .normal => .composing <|> { _ in
+                markedTextProperty.swap(":")
             },
             UserInput.isInput <|> .composing => .composing <|> {
                 $0.ifInput { text in

--- a/Sources/Automaton/EmojiAutomaton.swift
+++ b/Sources/Automaton/EmojiAutomaton.swift
@@ -33,7 +33,7 @@ public class EmojiAutomaton {
         let mappings: [ActionMapping<InputMethodState, UserInput>] = [
             /*  Input <|> fromState => toState <|> action */
             /* -------------------------------------------*/
-            .colon <|> .normal => .composing <|> { _ in
+            UserInput.typeof(.colon) <|> .normal => .composing <|> { _ in
                 markedTextProperty.swap(":")
                 candidatesProperty.swap([])
             },
@@ -43,15 +43,15 @@ public class EmojiAutomaton {
                     candidatesProperty.swap(dictionary.find(prefix: text))
                 }
             },
-            .backspace <|> {
+            UserInput.typeof(.backspace) <|> {
                     $0 == .composing && (markedTextProperty.value.utf8.count <= 1)
                 } => .normal <|> { _ in
                     markedTextProperty.swap("")
                     candidatesProperty.swap([])
                 },
-            .backspace <|> .composing  => .composing <|>
+            UserInput.typeof(.backspace) <|> .composing  => .composing <|>
                 markedTextProperty.modify { $0.removeLast() },
-            .enter <|> .composing => .normal <|> { _ in
+            UserInput.typeof(.enter) <|> .composing => .normal <|> { _ in
                 textObserver.send(value: markedTextProperty.value)
                 markedTextProperty.swap("")
                 candidatesProperty.swap([])

--- a/Sources/Automaton/InputMethodState.swift
+++ b/Sources/Automaton/InputMethodState.swift
@@ -9,4 +9,5 @@
 public enum InputMethodState {
     case normal
     case composing
+    case selection
 }

--- a/Sources/Automaton/UserInput.swift
+++ b/Sources/Automaton/UserInput.swift
@@ -5,15 +5,25 @@
 //  Created by mzp on 2017/09/19.
 //  Copyright © 2017 mzp. All rights reserved.
 //
+import AppKit
 
-public enum UserInput {
-    case input(text: String)
-    case backspace
-    case enter
-    case colon
+public class UserInput {
+    enum EventType {
+        case input(text: String)
+        case backspace
+        case enter
+        case colon
+    }
+    let eventType: EventType
+    let originalEvent: NSEvent?
+
+    // MARK: - predicate
+    static func typeof(_ eventType: EventType) -> (UserInput) -> Bool {
+        return { $0.eventType == eventType }
+    }
 
     static func isInput(_ state: UserInput) -> Bool {
-        switch state {
+        switch state.eventType {
         case .input:
             return true
         default:
@@ -22,17 +32,23 @@ public enum UserInput {
     }
 
     func ifInput(action: (String) -> Void) {
-        switch self {
+        switch self.eventType {
         case .input(text: let text):
             action(text)
         default:
             ()
         }
     }
+
+    // MARK: - initialize
+    init(eventType: EventType, originalEvent: NSEvent? = nil) {
+        self.eventType = eventType
+        self.originalEvent = originalEvent
+    }
 }
 
-extension UserInput: Equatable {
-    public static func == (lhs: UserInput, rhs: UserInput) -> Bool {
+extension UserInput.EventType: Equatable {
+    public static func == (lhs: UserInput.EventType, rhs: UserInput.EventType) -> Bool {
         switch (lhs, rhs) {
         case (.enter, .enter):
             return true

--- a/Sources/Automaton/UserInput.swift
+++ b/Sources/Automaton/UserInput.swift
@@ -10,6 +10,7 @@ public enum UserInput {
     case input(text: String)
     case backspace
     case enter
+    case colon
 
     static func isInput(_ state: UserInput) -> Bool {
         switch state {
@@ -36,6 +37,8 @@ extension UserInput: Equatable {
         case (.enter, .enter):
             return true
         case (.backspace, .backspace):
+            return true
+        case (.colon, .colon):
             return true
         case (.input(text: let text1), .input(text: let text2)):
             return text1 == text2

--- a/Sources/Automaton/UserInput.swift
+++ b/Sources/Automaton/UserInput.swift
@@ -14,6 +14,7 @@ public class UserInput {
         case enter
         case colon
         case other
+        case selected(candidate: String)
     }
     let eventType: EventType
     let originalEvent: NSEvent?
@@ -32,10 +33,28 @@ public class UserInput {
         }
     }
 
+    static func isSelected(_ state: UserInput) -> Bool {
+        switch state.eventType {
+        case .selected:
+            return true
+        default:
+            return false
+        }
+    }
+
     func ifInput(action: (String) -> Void) {
         switch self.eventType {
         case .input(text: let text):
             action(text)
+        default:
+            ()
+        }
+    }
+
+    func ifSelected(action: (String) -> Void) {
+        switch self.eventType {
+        case .selected(candidate: let candidate):
+            action(candidate)
         default:
             ()
         }
@@ -61,6 +80,8 @@ extension UserInput.EventType: Equatable {
             return text1 == text2
         case (.other, .other):
             return true
+        case (.selected(candidate: let candidate1), .selected(candidate: let candidate2)):
+            return candidate1 == candidate2
         default:
             return false
         }

--- a/Sources/Automaton/UserInput.swift
+++ b/Sources/Automaton/UserInput.swift
@@ -13,6 +13,7 @@ public class UserInput {
         case backspace
         case enter
         case colon
+        case other
     }
     let eventType: EventType
     let originalEvent: NSEvent?
@@ -58,6 +59,8 @@ extension UserInput.EventType: Equatable {
             return true
         case (.input(text: let text1), .input(text: let text2)):
             return text1 == text2
+        case (.other, .other):
+            return true
         default:
             return false
         }

--- a/Sources/Dictionary/EmojiDictionary.swift
+++ b/Sources/Dictionary/EmojiDictionary.swift
@@ -1,0 +1,15 @@
+//
+//  EmojiDictionary.swift
+//  EmojiIM
+//
+//  Created by mzp on 2017/10/13.
+//  Copyright © 2017 mzp. All rights reserved.
+//
+
+// TODO: introduce some protocol
+internal class EmojiDictionary {
+    func find(prefix: String) -> [String] {
+        // TODO: return entry starting with prefix
+        return ["🍣", "🍉", "🌻", "🚟"]
+    }
+}

--- a/Sources/InputMethodKit/EmojiInputController.swift
+++ b/Sources/InputMethodKit/EmojiInputController.swift
@@ -44,25 +44,30 @@ open class EmojiInputController: IMKInputController {
     open override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
         NSLog("handle(\(event)")
 
-        if event.keyCode == 36 {
-            return automaton.handle(.enter)
-        } else if event.keyCode == 51 {
-            return automaton.handle(.backspace)
-        } else if let text = event.characters {
-            if text == ":" {
-                return automaton.handle(.colon)
-            } else {
-                return automaton.handle(.input(text: text))
-            }
-        } else {
-            return false
-        }
+        return automaton.handle(UserInput(eventType: convert(event: event), originalEvent: event))
     }
 
     open override func menu() -> NSMenu! {
         return NSMenu(title: "EmojiIM") ※ { menu in
             menu.addItem(NSMenuItem(title: kBuiltDate, action: nil, keyEquivalent: ""))
             menu.addItem(NSMenuItem(title: kRevision, action: nil, keyEquivalent: ""))
+        }
+    }
+
+    private func convert(event: NSEvent) -> UserInput.EventType {
+        if event.keyCode == 36 {
+            return .enter
+        } else if event.keyCode == 51 {
+            return .backspace
+        } else if let text = event.characters {
+            switch text {
+            case ":":
+                return .colon
+            default:
+                return .input(text: text)
+            }
+        } else {
+            return .other
         }
     }
 }

--- a/Sources/InputMethodKit/EmojiInputController.swift
+++ b/Sources/InputMethodKit/EmojiInputController.swift
@@ -13,10 +13,16 @@ import InputMethodKit
 open class EmojiInputController: IMKInputController {
     private let automaton: EmojiAutomaton = EmojiAutomaton()
     private let candidates: IMKCandidates
+    private let printable: CharacterSet
 
     // swiftlint:disable:next implicitly_unwrapped_optional
     public override init!(server: IMKServer!, delegate: Any!, client inputClient: Any!) {
         self.candidates = IMKCandidates(server: server, panelType: kIMKMain)
+        self.printable = [
+            CharacterSet.alphanumerics,
+            CharacterSet.symbols,
+            CharacterSet.punctuationCharacters
+        ].reduce(CharacterSet()) { $0.union($1) }
         super.init(server: server, delegate: delegate, client: inputClient)
 
         guard let client = inputClient as? IMKTextInput else {
@@ -64,7 +70,11 @@ open class EmojiInputController: IMKInputController {
             case ":":
                 return .colon
             default:
-                return .input(text: text)
+                if !text.unicodeScalars.contains { !printable.contains($0) } {
+                    return .input(text: text)
+                } else {
+                    return .other
+                }
             }
         } else {
             return .other

--- a/Sources/InputMethodKit/EmojiInputController.swift
+++ b/Sources/InputMethodKit/EmojiInputController.swift
@@ -44,6 +44,9 @@ open class EmojiInputController: IMKInputController {
                 self.candidates.show(kIMKLocateCandidatesBelowHint)
             }
         }
+        automaton.candidateEvent.observeValues {
+            self.candidates.interpretKeyEvents([$0])
+        }
     }
 
     // swiftlint:disable:next implicitly_unwrapped_optional
@@ -113,6 +116,9 @@ extension EmojiInputController {
     // swiftlint:disable:next implicitly_unwrapped_optional
     open override func candidateSelected(_ candidateString: NSAttributedString!) {
         NSLog("%@", "\(#function)")
+        DispatchQueue.main.async {
+            _ = self.automaton.handle(UserInput(eventType: .selected(candidate: candidateString.string)))
+        }
     }
 
     // swiftlint:disable:next implicitly_unwrapped_optional

--- a/Sources/InputMethodKit/EmojiInputController.swift
+++ b/Sources/InputMethodKit/EmojiInputController.swift
@@ -39,7 +39,11 @@ open class EmojiInputController: IMKInputController {
         } else if event.keyCode == 51 {
             return automaton.handle(.backspace)
         } else if let text = event.characters {
-            return automaton.handle(.input(text: text))
+            if text == ":" {
+                return automaton.handle(.colon)
+            } else {
+                return automaton.handle(.input(text: text))
+            }
         } else {
             return false
         }

--- a/Tests/Automaton/AutomatonTest.swift
+++ b/Tests/Automaton/AutomatonTest.swift
@@ -25,19 +25,19 @@ open class AutomatonTest: XCTestCase {
     open func testTransition() {
         XCTAssertEqual(automaton.state.value, .normal)
 
-        _ = automaton.handle(.enter)
+        _ = automaton.handle(UserInput(eventType: .enter))
         XCTAssertEqual(automaton.state.value, .normal)
 
-        _ = automaton.handle(.input(text: "a"))
+        _ = automaton.handle(UserInput(eventType: .input(text: "a")))
         XCTAssertEqual(automaton.state.value, .normal)
 
-        _ = automaton.handle(.colon)
+        _ = automaton.handle(UserInput(eventType: .colon))
         XCTAssertEqual(automaton.state.value, .composing)
 
-        _ = automaton.handle(.input(text: "b"))
+        _ = automaton.handle(UserInput(eventType: .input(text: "b")))
         XCTAssertEqual(automaton.state.value, .composing)
 
-        _ = automaton.handle(.enter)
+        _ = automaton.handle(UserInput(eventType: .enter))
         XCTAssertEqual(automaton.state.value, .normal)
     }
 
@@ -45,45 +45,45 @@ open class AutomatonTest: XCTestCase {
         var text: String = ""
         automaton.text.observeValues { text.append($0) }
 
-        _ = automaton.handle(.colon)
+        _ = automaton.handle(UserInput(eventType: .colon))
         XCTAssertEqual(automaton.markedText.value, ":")
 
-        _ = automaton.handle(.input(text: "a"))
+        _ = automaton.handle(UserInput(eventType: .input(text: "a")))
         XCTAssertEqual(automaton.markedText.value, ":a")
 
-       _ = automaton.handle(.backspace)
+       _ = automaton.handle(UserInput(eventType: .backspace))
         XCTAssertEqual(automaton.markedText.value, ":")
 
-        _ = automaton.handle(.enter)
+        _ = automaton.handle(UserInput(eventType: .enter))
         XCTAssertEqual(automaton.markedText.value, "")
         XCTAssertEqual(text, ":")
     }
 
     open func testCandidates() {
-        _ = automaton.handle(.colon)
+        _ = automaton.handle(UserInput(eventType: .colon))
         XCTAssertEqual(automaton.candidates.value, [])
 
-        _ = automaton.handle(.input(text: "s"))
+        _ = automaton.handle(UserInput(eventType: .input(text: "s")))
         XCTAssertTrue(automaton.candidates.value.contains("🍣"), "\(automaton.candidates.value) doesn't contain 🍣")
 
-        _ = automaton.handle(.enter)
+        _ = automaton.handle(UserInput(eventType: .enter))
         XCTAssertEqual(automaton.candidates.value, [])
     }
 
     open func testBackspaceReturnNormal() {
-        _ = automaton.handle(.colon)
-        _ = automaton.handle(.input(text: "a"))
-        _ = automaton.handle(.backspace)
+        _ = automaton.handle(UserInput(eventType: .colon))
+        _ = automaton.handle(UserInput(eventType: .input(text: "a")))
+        _ = automaton.handle(UserInput(eventType: .backspace))
         XCTAssertEqual(automaton.state.value, .composing)
-        _ = automaton.handle(.backspace)
+        _ = automaton.handle(UserInput(eventType: .backspace))
         XCTAssertEqual(automaton.state.value, .normal)
     }
 
     open func testHandled() {
-        XCTAssertFalse(automaton.handle(.input(text: "a")))
-        XCTAssertTrue(automaton.handle(.colon))
-        XCTAssertTrue(automaton.handle(.input(text: "a")))
-        XCTAssertTrue(automaton.handle(.enter))
-        XCTAssertFalse(automaton.handle(.enter))
+        XCTAssertFalse(automaton.handle(UserInput(eventType: .input(text: "a"))))
+        XCTAssertTrue(automaton.handle(UserInput(eventType: .colon)))
+        XCTAssertTrue(automaton.handle(UserInput(eventType: .input(text: "a"))))
+        XCTAssertTrue(automaton.handle(UserInput(eventType: .enter)))
+        XCTAssertFalse(automaton.handle(UserInput(eventType: .enter)))
     }
 }

--- a/Tests/Automaton/AutomatonTest.swift
+++ b/Tests/Automaton/AutomatonTest.swift
@@ -59,6 +59,17 @@ open class AutomatonTest: XCTestCase {
         XCTAssertEqual(text, ":")
     }
 
+    open func testCandidates() {
+        _ = automaton.handle(.colon)
+        XCTAssertEqual(automaton.candidates.value, [])
+
+        _ = automaton.handle(.input(text: "s"))
+        XCTAssertTrue(automaton.candidates.value.contains("🍣"), "\(automaton.candidates.value) doesn't contain 🍣")
+
+        _ = automaton.handle(.enter)
+        XCTAssertEqual(automaton.candidates.value, [])
+    }
+
     open func testBackspaceReturnNormal() {
         _ = automaton.handle(.colon)
         _ = automaton.handle(.input(text: "a"))

--- a/Tests/Automaton/AutomatonTest.swift
+++ b/Tests/Automaton/AutomatonTest.swift
@@ -29,6 +29,9 @@ open class AutomatonTest: XCTestCase {
         XCTAssertEqual(automaton.state.value, .normal)
 
         _ = automaton.handle(.input(text: "a"))
+        XCTAssertEqual(automaton.state.value, .normal)
+
+        _ = automaton.handle(.colon)
         XCTAssertEqual(automaton.state.value, .composing)
 
         _ = automaton.handle(.input(text: "b"))
@@ -42,22 +45,22 @@ open class AutomatonTest: XCTestCase {
         var text: String = ""
         automaton.text.observeValues { text.append($0) }
 
-        _ = automaton.handle(.input(text: "a"))
-        XCTAssertEqual(automaton.markedText.value, "a")
+        _ = automaton.handle(.colon)
+        XCTAssertEqual(automaton.markedText.value, ":")
 
-        _ = automaton.handle(.input(text: "b"))
-        XCTAssertEqual(automaton.markedText.value, "ab")
+        _ = automaton.handle(.input(text: "a"))
+        XCTAssertEqual(automaton.markedText.value, ":a")
 
        _ = automaton.handle(.backspace)
-        XCTAssertEqual(automaton.markedText.value, "a")
+        XCTAssertEqual(automaton.markedText.value, ":")
 
         _ = automaton.handle(.enter)
         XCTAssertEqual(automaton.markedText.value, "")
-        XCTAssertEqual(text, "a")
+        XCTAssertEqual(text, ":")
     }
 
     open func testBackspaceReturnNormal() {
-        _ = automaton.handle(.input(text: "a"))
+        _ = automaton.handle(.colon)
         _ = automaton.handle(.input(text: "a"))
         _ = automaton.handle(.backspace)
         XCTAssertEqual(automaton.state.value, .composing)
@@ -66,7 +69,8 @@ open class AutomatonTest: XCTestCase {
     }
 
     open func testHandled() {
-        XCTAssertTrue(automaton.handle(.input(text: "a")))
+        XCTAssertFalse(automaton.handle(.input(text: "a")))
+        XCTAssertTrue(automaton.handle(.colon))
         XCTAssertTrue(automaton.handle(.input(text: "a")))
         XCTAssertTrue(automaton.handle(.enter))
         XCTAssertFalse(automaton.handle(.enter))


### PR DESCRIPTION
[IMKCandidates](https://developer.apple.com/documentation/inputmethodkit/imkcandidates) provides features to show candidates and select one of them.

![candidate](https://user-images.githubusercontent.com/9650/31575902-fbbfdf40-b0df-11e7-9424-3e942862b5be.gif)

## 👀Show candidate window
By `show(IMKCandidatesLocationHint)` of `IMKCandidates`, candidate window will be shown.

```swift
let candidates: IMKCandidates = IMKCandidates(server: server,
                                              panelType: kIMKSingleColumnScrollingCandidatePanel,
                                              styleType: kIMKMain)
candidates.show(kIMKLocateCandidatesBelowHint)
```

Window style is specified `panelType:` argument. Available options are `kIMKSingleColumnScrollingCandidatePanel`, `KIMKScrollingGridCandidatePanel`, `KIMKSingleRowSteppingCandidatePanel `.

`kIMKSingleColumnScrollingCandidatePanel`:

<img width="109" alt="screen shot 2017-10-09 at 22 01 58" src="https://user-images.githubusercontent.com/9650/31576025-6d4c3544-b0e2-11e7-9bca-93bd4f8a5928.png">

`KIMKScrollingGridCandidatePanel`:

<img width="361" alt="screen shot 2017-10-09 at 22 05 29" src="https://user-images.githubusercontent.com/9650/31576026-6d7176ec-b0e2-11e7-81af-aba22f68fe73.png">

`KIMKSingleRowSteppingCandidatePanel `:

<img width="126" alt="screen shot 2017-10-09 at 22 07 53" src="https://user-images.githubusercontent.com/9650/31576027-6d96558e-b0e2-11e7-98fa-87b747114b95.png">

## 📖Obtain candidates
Candidates are loaded when `update()` of `IMKCandidates` is called.

```swift
candidates.update()
```

Candidates are obtain by `candidates(_:)` of `IMKInputController`.

```swift
open class EmojiInputController: IMKInputController {
  ...
  open override func candidates(_ sender: Any!) -> [Any] {
    return ["a", "b", "c"]
  }
}
```

## ⚡️ Candidate window
Candidate window can be manipulated through keyboard. E.g. move selection candidate by up/down key.

To achieve this, we should pass key event to candidate window.

```swift
open class EmojiInputController: IMKInputController {
  ...
  open override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
    if /* check if candidate window is shown */ {
      candidates.interpretKeyEvents([event])
      return true
    }
    return false
  }
  ...
}
```

## 👉Select candidate
When candidate's selection moved, IMKInputController method is called.

```swift
open class EmojiInputController: IMKInputController {
  ...
  open override func candidateSelected(_ candidateString: NSAttributedString!) {
      // when candidate selection moved
  }

  open override func candidateSelectionChanged(_ candidateString: NSAttributedString!) {
      // when candidate is selected
  }
  ...
}
```

## 🍎 Apple API internal information
Some method of IMKCandidates doesn't work. In my reverse engineering, following method has empty implementation, so doesn't work.

 * `func showAnnotation(NSAttributedString!)`
 * `func attachChild(IMKCandidates!, toCandidate: Int, type: IMKStyleType)`
 * `func showChild()`
 * `func showSublist([Any]!, subListDelegate: Any!)`
 * `func detachChild(Int)`
 * `func hideChild()`
 * `func candidateIdentifier(atLineNumber: Int)`
 * `func candidateStringIdentifier(Any!)`
 * `func lineNumberForCandidate(withIdentifier: Int)`
 * `func selectCandidate(Int)`
 * `func selectCandidate(withIdentifier: Int)`
 * `func clearSelection()`

I reported this to Apple ([rdar://34944196](http://www.openradar.me/34944196), [rdar://34911503](http://www.openradar.me/34911503))

## ✏️ Design decision: EmojiAutomaton
I enhanced emoji im automaton to show emoji candidates.

### Manipulation
I decided to use following manipulation.

 1. Press `:` into composing mode.
 2. While inputing composing text, emoji candidates is shown.
 3. Press arrow key into select mode.
 4. When `InputController`'s method is called, state changed into normal mode.

### Store NSEvent
To pass original `NSEvent` to candidate window, I extended user input to store its. 

```swift
public class UserInput {
    enum EventType {
        case input(text: String)
        case backspace
        case enter
        case colon
    }
    let eventType: EventType
    let originalEvent: NSEvent?
}
```

See https://github.com/mzp/EmojiIM/pull/8/commits/e88bb84e69ce8d0dcd252a1904f029c50f984928 for detail.

### Extended automaton 
Add new user input type for non-text key(e.g. arrow key) and candidate select.

```swift
    enum EventType {
        case input(text: String)
        case backspace
        case enter
        case colon
        case other // <- NEW
        case selected(candidate: String) // <- NEW
    }
```

Add new state for candidate selection.

```swift
public enum InputMethodState {
    case normal
    case composing
    case selection
}
```

Add new transition.

```swift
let mappings: [ActionMapping<InputMethodState, UserInput>] = [
  ...
  UserInput.typeof(.other) <|> .composing => .selection,
  UserInput.isSelected <|> .selection => .normal,
  { _ in true } <|> .selection => .selection
}
```

## 🚧 WIP area
 * Emoji dictionary
 * `selectionKey` support