### PR TITLE
Remove Hint: it doesn't take any effect.

### DIFF
--- a/Sources/InputMethodKit/EmojiInputController.swift
+++ b/Sources/InputMethodKit/EmojiInputController.swift
@@ -41,7 +41,7 @@ open class EmojiInputController: IMKInputController {
                 self.candidates.hide()
             } else {
                 self.candidates.update()
-                self.candidates.show(kIMKLocateCandidatesBelowHint)
+                self.candidates.show()
             }
         }
         automaton.candidateEvent.observeValues {


### PR DESCRIPTION
At macOS High Sierra, this method only call `-[IMKCandidates updateAndShowCandidates]`,
so we have no need to use this.

    -[IMKCandidates show:]:
    0000000000055959. pushq.%rbp
    000000000005595a. movq. %rsp, %rbp
    000000000005595d. movq. _OBJC_IVAR_$_IMKCandidates._private(%rip), %rax
    0000000000055964. movq. (%rdi,%rax), %rdi
    0000000000055968. movq. 0x81809(%rip), %rsi ## Objc selector ref: updateAndShowCandidates
    000000000005596f. popq. %rbp
    0000000000055970. jmpq. *0x59912(%rip) ## Objc message: -[%rdi updateAndShowCandidates]