### PR TITLE
Implement InputMode

### DIFF
--- a/EmojiIM.xcodeproj/project.pbxproj
+++ b/EmojiIM.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		134922DF1F6B33AF000AA483 /* EmojiInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134922DE1F6B33AF000AA483 /* EmojiInputController.swift */; };
 		134A02F01F6B36C60050216F /* InputMethodIcon.tiff in Resources */ = {isa = PBXBuildFile; fileRef = 134922E01F6B33B9000AA483 /* InputMethodIcon.tiff */; };
 		136A4CCD1F904CA20020BDBE /* EmojiDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136A4CCC1F904CA20020BDBE /* EmojiDictionary.swift */; };
+		13A455CD1F9F5D2900F2D3EA /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 13A455CF1F9F5D2900F2D3EA /* InfoPlist.strings */; };
 		13AE25131F9052730073912E /* EmojiDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136A4CCC1F904CA20020BDBE /* EmojiDictionary.swift */; };
 		13B7E6621F6D6327008C528A /* BuildInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B7E6611F6D631F008C528A /* BuildInfo.swift */; };
 		13BE30431F731F7B001D3AF8 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13BE30421F731F7B001D3AF8 /* Tests.swift */; };
@@ -64,6 +65,7 @@
 		134922DE1F6B33AF000AA483 /* EmojiInputController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiInputController.swift; sourceTree = "<group>"; };
 		134922E01F6B33B9000AA483 /* InputMethodIcon.tiff */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = InputMethodIcon.tiff; sourceTree = "<group>"; };
 		136A4CCC1F904CA20020BDBE /* EmojiDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiDictionary.swift; sourceTree = "<group>"; };
+		13A455D01F9F5E1D00F2D3EA /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		13B7E6611F6D631F008C528A /* BuildInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildInfo.swift; sourceTree = "<group>"; };
 		13BE30401F731F7B001D3AF8 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		13BE30421F731F7B001D3AF8 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
@@ -131,9 +133,10 @@
 		130DC5D31F65F91D00BBCB60 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				130DC5DB1F65F91D00BBCB60 /* Info.plist */,
+				13A455CF1F9F5D2900F2D3EA /* InfoPlist.strings */,
 				130DC5D61F65F91D00BBCB60 /* Assets.xcassets */,
 				130DC5D81F65F91D00BBCB60 /* MainMenu.xib */,
-				130DC5DB1F65F91D00BBCB60 /* Info.plist */,
 				134922E01F6B33B9000AA483 /* InputMethodIcon.tiff */,
 				130423681F6C9927008989B1 /* InputMethodIcon@2x.tiff */,
 				130DC5DC1F65F91D00BBCB60 /* EmojiIM.entitlements */,
@@ -346,6 +349,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				134A02F01F6B36C60050216F /* InputMethodIcon.tiff in Resources */,
+				13A455CD1F9F5D2900F2D3EA /* InfoPlist.strings in Resources */,
 				1313B8271F935DAA004B6A2F /* EmojiDefinition.json in Resources */,
 				130DC5D71F65F91D00BBCB60 /* Assets.xcassets in Resources */,
 				130DC5DA1F65F91D00BBCB60 /* MainMenu.xib in Resources */,
@@ -568,6 +572,14 @@
 				130DC5D91F65F91D00BBCB60 /* Base */,
 			);
 			name = MainMenu.xib;
+			sourceTree = "<group>";
+		};
+		13A455CF1F9F5D2900F2D3EA /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				13A455D01F9F5E1D00F2D3EA /* Base */,
+			);
+			name = InfoPlist.strings;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */

--- a/Resources/Base.lproj/InfoPlist.strings
+++ b/Resources/Base.lproj/InfoPlist.strings
@@ -1,0 +1,5 @@
+CFBundleName = "Emoji IM";
+
+com.apple.inputmethod.Roman = "Emoji(Alphabet)";
+
+jp.mzp.inputmethod.EmojiIM = "Emoji";

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -50,5 +50,38 @@
 	</array>
 	<key>tsInputMethodIconFileKey</key>
 	<string>InputMethodIcon.tiff</string>
+	<key>ComponentInputModeDict</key>
+	<dict>
+		<key>tsInputModeListKey</key>
+		<dict>
+			<key>jp.mzp.inputmethod.EmojiIM</key>
+			<dict>
+				<key>tsInputModeScriptKey</key>
+				<string>smUnicode</string>
+				<key>tsInputModeMenuIconFileKey</key>
+				<string>InputMethodIcon.tiff</string>
+				<key>tsInputModeAlternateMenuIconFileKey</key>
+				<string>InputMethodIcon.tiff</string>
+				<key>tsInputModeDefaultStateKey</key>
+				<true/>
+			</dict>
+			<key>com.apple.inputmethod.Roman</key>
+			<dict>
+				<key>tsInputModeScriptKey</key>
+				<string>smRoman</string>
+				<key>tsInputModeMenuIconFileKey</key>
+				<string>InputMethodIcon.tiff</string>
+				<key>tsInputModeAlternateMenuIconFileKey</key>
+				<string>InputMethodIcon.tiff</string>
+				<key>tsInputModeDefaultStateKey</key>
+				<true/>
+			</dict>
+		</dict>
+		<key>tsVisibleInputModeOrderedArrayKey</key>
+		<array>
+			<string>jp.mzp.inputmethod.EmojiIM</string>
+			<string>com.apple.inputmethod.Roman</string>
+		</array>
+	</dict>
 </dict>
 </plist>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -38,10 +38,6 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>TISInputSourceID</key>
-	<string>jp.mzp.inputmethod.EmojiIM</string>
-	<key>TISIntendedLanguage</key>
-	<string>ja</string>
 	<key>tsInputMethodCharacterRepertoireKey</key>
 	<array>
 		<string>Hira</string>
@@ -56,6 +52,10 @@
 		<dict>
 			<key>jp.mzp.inputmethod.EmojiIM</key>
 			<dict>
+				<key>TISInputSourceID</key>
+				<string>jp.mzp.inputmethod.EmojiIM.emoji</string>
+				<key>TISIntendedLanguage</key>
+				<string>en</string>
 				<key>tsInputModeScriptKey</key>
 				<string>smUnicode</string>
 				<key>tsInputModeMenuIconFileKey</key>
@@ -67,6 +67,10 @@
 			</dict>
 			<key>com.apple.inputmethod.Roman</key>
 			<dict>
+				<key>TISInputSourceID</key>
+				<string>jp.mzp.inputmethod.EmojiIM.roman</string>
+				<key>TISIntendedLanguage</key>
+				<string>en</string>
 				<key>tsInputModeScriptKey</key>
 				<string>smRoman</string>
 				<key>tsInputModeMenuIconFileKey</key>

--- a/Sources/InputMethodKit/EmojiInputController.swift
+++ b/Sources/InputMethodKit/EmojiInputController.swift
@@ -13,6 +13,7 @@ import InputMethodKit
 internal class EmojiInputController: IMKInputController {
     private let automaton: EmojiAutomaton = EmojiAutomaton()
     private let candidates: IMKCandidates
+    private var directMode: Bool = false
     private let printable: CharacterSet = [
         CharacterSet.alphanumerics,
         CharacterSet.symbols,
@@ -49,6 +50,9 @@ internal class EmojiInputController: IMKInputController {
 
     override func handle(_ event: NSEvent, client sender: Any) -> Bool {
         NSLog("%@", "\(#function)((\(event), client: \(sender))")
+        if directMode {
+            return false
+        }
 
         return automaton.handle(UserInput(eventType: convert(event: event), originalEvent: event))
     }
@@ -97,8 +101,16 @@ extension EmojiInputController /* IMKStateSetting*/ {
         self.candidates.hide()
     }
 
-    override func setValue(_ value: Any?, forKey key: String) {
-        NSLog("%@", "\(#function)(\(value ?? "nil"), forKey: \(key))")
+    override func setValue(_ value: Any, forTag tag: Int, client sender: Any) {
+        NSLog("%@", "\(#function)(\(value), forTag: \(tag))")
+        guard let value = value as? NSString else {
+            return
+        }
+        guard let sender = sender as? IMKTextInput else {
+            return
+        }
+        directMode = value == "com.apple.inputmethod.Roman"
+        sender.overrideKeyboard(withKeyboardNamed: "com.apple.keylayout.US")
     }
 }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,7 +1,7 @@
 fastlane_version "2.56.0"
 
 default_platform :mac
-xcversion(version: '9.0')
+xcversion(version: '9.0.1')
 
 platform :mac do
   before_all do


### PR DESCRIPTION
## ✨ Introduce input mode
To demonstrate input mode, I added direct input mode. Direct input mode is pass-through all key event.

<img width="266" alt="screen shot 2017-10-24 at 16 20 44" src="https://user-images.githubusercontent.com/9650/31955227-4f160c6a-b8d7-11e7-9743-a56bd0b55583.png">

## :memo: How to implement
To define input mode, we should add some fields to Info.plist. A document about this is not missing, but fragmented.

### Required fields by TextService
Most of fields is required by TextService. This document is published at ADC and lost. But it remains at mirror site.  ([TN2128](http://mirror.informatimago.com/next/developer.apple.com/technotes/tn2005/tn2128.html))

>  Your Info.plist must specify the "ComponentInputModeDict" key. The value
> for the "ComponentInputModeDict" key is a dictionary that must define 2
> keys: "tsInputModeListKey" whose value is a dictionary that defines all
> your input modes, and "tsVisibleInputModeOrderedArrayKey" whose value is
> an array of input mode strings. This array defines how your input modes
> are ordered relative to one another in System provided UI. See
> kComponentBundleInputModeDictKey, kTSInputModeListKey, and
> kTSVisibleInputModeOrderedArrayKey in TextServices.h.
>
> The following sample would describe a mode-savvy input method, called
> "Special IM". It uses some TSM provided (standard) input modes for
> Japanese and Roman.
>
> All icon files reside in the component's Resources/ directory. These
> icon files can be TIFF (.tif) or .icns icons. .icns icons are
> preferrable because TSM automatically register them with Icon Services
> registry. The UI names for the input modes reside in InfoPlist.strings
> files for the various localizations. A sample for these is shown below.
>
> Some notes on the various input mode properties.
>
> Required properties:
>
> Input Modes are assigned a Mac ScriptCode, such as smJapanese (see
> tsInputModeScriptKey).
>
> If the input method defines several input modes in the same script, at
> most one of these should be marked as the "primary" input mode for that
> script. See tsInputModePrimaryInScriptKey.
>
> Each input mode should define an icon to be used in the TextInput menu
> to show when the input mode is selected.
>
> An "alternate" icon should also be defined for use when the user clicks
> the icon in the menu bar. See tsInputModeMenuIconFileKey and
> tsInputModeAlternateMenuIconFileKey.
>
> Input Modes can be enabled by default when the input method itself is
> enabled in System Preferences/International Prefs pane. This is
> specified via tsInputModeDefaultStateKey. Those input modes for which
> this key is 'false' are not automatically "checked" in International
> Preferences.

### Required fields by TextInputSource
This document is described at [TextInputSources.h](https://github.com/phracker/MacOSX-SDKs/blob/master/MacOSX10.6.sdk/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/Headers/TextInputSources.h)

> An input method's input modes are defined using the "ComponentInputModeDict"
> key at the top level of the input method's Info.plist file (even for
> non-component application-based input methods). The value of this key is a
> dictionary, one of whose keys is "tsInputModeListKey"; the value of this
> key is also a dictionary of input modes, with the InputModeID as the key
> and the input mode's dictionary as the value (see TextServices.h).
>
> The new keys keys "TISInputSourceID" and "TISIntendedLanguage" and their
> associated values are added to the input mode's dictionary.
>
> "TISInputSourceID" note: For input modes this is a string that begins with
> the parent input method's InputSourceID or BundleID, followed by something
> that identifies the mode. For example, "com.apple.Kotoeri.Japanese.Katakana".
> In general it is not necessarily the same as the InputModeID, since a
> particular InputModeID such as "com.apple.inputmethod.Japanese.Katakana"
> may be used by multiple input methods. If this key is not specified, an
> InputSourceID will be constructed by combining the BundleID with an
> InputModeID suffix formed by deleting any prefix that matches the BundleID
> or that ends in ".inputmethod."

### 🖋 What's happen when switching input mode
When switch input mode, [setValue:forTag:client:](https://developer.apple.com/documentation/inputmethodkit/imkstatesetting/1385412-setvalue?language=objc) of IMKStateSetting.

## :bug: Related issues
https://gist.github.com/pkamb/e0b5bf90e45cad714588feaf14eba523