### PR TITLE
Secret of input modes

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -48,6 +48,8 @@
 	<string>InputMethodIcon.tiff</string>
 	<key>ComponentInputModeDict</key>
 	<dict>
+		<key>TISUnifiedUIForInputMethodEnabling</key>
+		<true/>
 		<key>tsInputModeListKey</key>
 		<dict>
 			<key>jp.mzp.inputmethod.EmojiIM</key>
@@ -89,5 +91,7 @@
 			<string>com.apple.inputmethod.Roman</string>
 		</array>
 	</dict>
+	<key>TISIntendedLanguage</key>
+	<string>en</string>
 </dict>
 </plist>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -52,6 +52,8 @@
 		<dict>
 			<key>jp.mzp.inputmethod.EmojiIM</key>
 			<dict>
+				<key>TISDoubleSpaceSubstitution</key>
+				<string>🍣</string>
 				<key>TISInputSourceID</key>
 				<string>jp.mzp.inputmethod.EmojiIM.emoji</string>
 				<key>TISIntendedLanguage</key>


### PR DESCRIPTION
Use private API(key?) of input method for demonstration.

## TISDoubleSpaceSubstitution
Specify period for this language. This character used when we input double space at end of sentence.

<img width="670" alt="screen shot 2017-10-28 at 14 41 01" src="https://user-images.githubusercontent.com/9650/32135463-2afda908-bbef-11e7-9eba-fe3289347a43.png">

## TISUnifiedUIForInputMethodEnabling
We usually toggle on/off for each input mode. When this key is enabled, we can toggle input modes at once. This function is only used by JapaneseIM.

With this key:

<img width="571" alt="screen shot 2017-10-28 at 22 47 00" src="https://user-images.githubusercontent.com/9650/32135494-b339354e-bbef-11e7-8ac6-0823a318a780.png">

Without this key:

<img width="596" alt="screen shot 2017-10-28 at 15 01 18" src="https://user-images.githubusercontent.com/9650/32135572-e7b4a83e-bbf0-11e7-840e-e18afbc2e749.png">







