### PR TITLE
Add keyboard layout setting

### DIFF
--- a/EmojiIM.xcodeproj/project.pbxproj
+++ b/EmojiIM.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		13C46F271FB86E14005A8348 /* NSTextField+Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C46F241FB86E0E005A8348 /* NSTextField+Label.swift */; };
 		13C46F281FB86EB3005A8348 /* BuildInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B7E6611F6D631F008C528A /* BuildInfo.swift */; };
 		13D45CD21F9340F600D4CE5D /* ComposingMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13D45CD11F9340F600D4CE5D /* ComposingMapping.swift */; };
+		13DD45F41FB9C9D100EE1758 /* SettingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13EBC2FE1FB91FA20036A072 /* SettingStore.swift */; };
+		13EBC3001FB91FC90036A072 /* SettingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13EBC2FE1FB91FA20036A072 /* SettingStore.swift */; };
 		13EBC3021FB9B1790036A072 /* TISInputSource+Property.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13EBC3011FB9B1790036A072 /* TISInputSource+Property.swift */; };
 		13FFA3881F93450200852AC5 /* MappingDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FFA3871F93450200852AC5 /* MappingDefinition.swift */; };
 		13FFA38A1F93455B00852AC5 /* NormalMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FFA3891F93455B00852AC5 /* NormalMapping.swift */; };
@@ -113,6 +115,7 @@
 		13C46F241FB86E0E005A8348 /* NSTextField+Label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTextField+Label.swift"; sourceTree = "<group>"; };
 		13C46F251FB86E0E005A8348 /* Collection+Every.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Every.swift"; sourceTree = "<group>"; };
 		13D45CD11F9340F600D4CE5D /* ComposingMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposingMapping.swift; sourceTree = "<group>"; };
+		13EBC2FE1FB91FA20036A072 /* SettingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingStore.swift; sourceTree = "<group>"; };
 		13EBC3011FB9B1790036A072 /* TISInputSource+Property.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TISInputSource+Property.swift"; sourceTree = "<group>"; };
 		13FFA3871F93450200852AC5 /* MappingDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MappingDefinition.swift; sourceTree = "<group>"; };
 		13FFA3891F93455B00852AC5 /* NormalMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalMapping.swift; sourceTree = "<group>"; };
@@ -198,6 +201,7 @@
 				13C46F231FB86DF4005A8348 /* Extension */,
 				13BE304A1F73222F001D3AF8 /* InputMethodKit */,
 				13AC721E1FAD4D7200585E3B /* Preferences */,
+				13EBC2FD1FB91F410036A072 /* Setting */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -298,6 +302,14 @@
 				13EBC3011FB9B1790036A072 /* TISInputSource+Property.swift */,
 			);
 			path = Extension;
+			sourceTree = "<group>";
+		};
+		13EBC2FD1FB91F410036A072 /* Setting */ = {
+			isa = PBXGroup;
+			children = (
+				13EBC2FE1FB91FA20036A072 /* SettingStore.swift */,
+			);
+			path = Setting;
 			sourceTree = "<group>";
 		};
 		13FFA3861F9344F200852AC5 /* Mapping */ = {
@@ -690,6 +702,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				13D45CD21F9340F600D4CE5D /* ComposingMapping.swift in Sources */,
+				13DD45F41FB9C9D100EE1758 /* SettingStore.swift in Sources */,
 				130DC5D51F65F91D00BBCB60 /* AppDelegate.swift in Sources */,
 				13FFA38C1F9345BF00852AC5 /* SelectionMapping.swift in Sources */,
 				13FFA3881F93450200852AC5 /* MappingDefinition.swift in Sources */,
@@ -710,6 +723,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				13EBC3021FB9B1790036A072 /* TISInputSource+Property.swift in Sources */,
+				13EBC3001FB91FC90036A072 /* SettingStore.swift in Sources */,
 				13779B981FB3351C001529BF /* Preferences.swift in Sources */,
 				13C46F281FB86EB3005A8348 /* BuildInfo.swift in Sources */,
 				13C46F271FB86E14005A8348 /* NSTextField+Label.swift in Sources */,

--- a/EmojiIM.xcodeproj/project.pbxproj
+++ b/EmojiIM.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		13C46F271FB86E14005A8348 /* NSTextField+Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C46F241FB86E0E005A8348 /* NSTextField+Label.swift */; };
 		13C46F281FB86EB3005A8348 /* BuildInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B7E6611F6D631F008C528A /* BuildInfo.swift */; };
 		13D45CD21F9340F600D4CE5D /* ComposingMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13D45CD11F9340F600D4CE5D /* ComposingMapping.swift */; };
+		13EBC3021FB9B1790036A072 /* TISInputSource+Property.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13EBC3011FB9B1790036A072 /* TISInputSource+Property.swift */; };
 		13FFA3881F93450200852AC5 /* MappingDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FFA3871F93450200852AC5 /* MappingDefinition.swift */; };
 		13FFA38A1F93455B00852AC5 /* NormalMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FFA3891F93455B00852AC5 /* NormalMapping.swift */; };
 		13FFA38C1F9345BF00852AC5 /* SelectionMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FFA38B1F9345BF00852AC5 /* SelectionMapping.swift */; };
@@ -90,6 +91,7 @@
 		130DC5DC1F65F91D00BBCB60 /* EmojiIM.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = EmojiIM.entitlements; sourceTree = "<group>"; };
 		1313B8221F935741004B6A2F /* EmojiDefinition.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = EmojiDefinition.json; sourceTree = "<group>"; };
 		1313B8231F93579E004B6A2F /* EmojiDictionaryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiDictionaryTest.swift; sourceTree = "<group>"; };
+		134427A11FB88D39002C68F9 /* BridgeHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BridgeHeader.h; sourceTree = "<group>"; };
 		134922DE1F6B33AF000AA483 /* EmojiInputController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiInputController.swift; sourceTree = "<group>"; };
 		134922E01F6B33B9000AA483 /* InputMethodIcon.tiff */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = InputMethodIcon.tiff; sourceTree = "<group>"; };
 		136A4CCC1F904CA20020BDBE /* EmojiDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiDictionary.swift; sourceTree = "<group>"; };
@@ -111,6 +113,7 @@
 		13C46F241FB86E0E005A8348 /* NSTextField+Label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTextField+Label.swift"; sourceTree = "<group>"; };
 		13C46F251FB86E0E005A8348 /* Collection+Every.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Every.swift"; sourceTree = "<group>"; };
 		13D45CD11F9340F600D4CE5D /* ComposingMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposingMapping.swift; sourceTree = "<group>"; };
+		13EBC3011FB9B1790036A072 /* TISInputSource+Property.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TISInputSource+Property.swift"; sourceTree = "<group>"; };
 		13FFA3871F93450200852AC5 /* MappingDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MappingDefinition.swift; sourceTree = "<group>"; };
 		13FFA3891F93455B00852AC5 /* NormalMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalMapping.swift; sourceTree = "<group>"; };
 		13FFA38B1F9345BF00852AC5 /* SelectionMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionMapping.swift; sourceTree = "<group>"; };
@@ -189,6 +192,7 @@
 			isa = PBXGroup;
 			children = (
 				130DC5D41F65F91D00BBCB60 /* AppDelegate.swift */,
+				134427A11FB88D39002C68F9 /* BridgeHeader.h */,
 				13BE30541F73255D001D3AF8 /* Automaton */,
 				136A4CCB1F904C870020BDBE /* Dictionary */,
 				13C46F231FB86DF4005A8348 /* Extension */,
@@ -291,6 +295,7 @@
 			children = (
 				13C46F251FB86E0E005A8348 /* Collection+Every.swift */,
 				13C46F241FB86E0E005A8348 /* NSTextField+Label.swift */,
+				13EBC3011FB9B1790036A072 /* TISInputSource+Property.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -704,6 +709,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				13EBC3021FB9B1790036A072 /* TISInputSource+Property.swift in Sources */,
 				13779B981FB3351C001529BF /* Preferences.swift in Sources */,
 				13C46F281FB86EB3005A8348 /* BuildInfo.swift in Sources */,
 				13C46F271FB86E14005A8348 /* NSTextField+Label.swift in Sources */,
@@ -932,6 +938,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = jp.mzp.emojiim.Preferences;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_OBJC_BRIDGING_HEADER = Sources/BridgeHeader.h;
 				SWIFT_VERSION = 4.0;
 				WRAPPER_EXTENSION = prefPane;
 			};
@@ -950,6 +957,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = jp.mzp.emojiim.Preferences;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_OBJC_BRIDGING_HEADER = Sources/BridgeHeader.h;
 				SWIFT_VERSION = 4.0;
 				WRAPPER_EXTENSION = prefPane;
 			};

--- a/Sources/BridgeHeader.h
+++ b/Sources/BridgeHeader.h
@@ -1,0 +1,14 @@
+//
+//  BridgeHeader.h
+//  EmojiIM
+//
+//  Created by mzp on 2017/11/12.
+//  Copyright © 2017 mzp. All rights reserved.
+//
+
+#ifndef BridgeHeader_h
+#define BridgeHeader_h
+
+#include <Carbon/Carbon.h>
+
+#endif /* BridgeHeader_h */

--- a/Sources/Extension/TISInputSource+Property.swift
+++ b/Sources/Extension/TISInputSource+Property.swift
@@ -1,0 +1,41 @@
+//
+//  TISInputSource+Property.swift
+//  Preferences
+//
+//  Created by mzp on 2017/11/13.
+//  Copyright © 2017 mzp. All rights reserved.
+//
+
+extension TISInputSource {
+    var localizedName: String {
+        return unsafeBitCast(
+            TISGetInputSourceProperty(self, kTISPropertyLocalizedName),
+            to: NSString.self) as String
+    }
+
+    var inputSourceID: String {
+        return unsafeBitCast(
+            TISGetInputSourceProperty(self, kTISPropertyInputSourceID),
+            to: NSString.self) as String
+    }
+
+    class func keyboardLayouts() -> [TISInputSource]? {
+        let conditions = CFDictionaryCreateMutable(nil, 2, nil, nil)
+        CFDictionaryAddValue(conditions,
+                             unsafeBitCast(kTISPropertyInputSourceType, to: UnsafeRawPointer.self),
+                             unsafeBitCast(kTISTypeKeyboardLayout, to: UnsafeRawPointer.self))
+        CFDictionaryAddValue(conditions,
+                             unsafeBitCast(kTISPropertyInputSourceIsASCIICapable, to: UnsafeRawPointer.self),
+                             unsafeBitCast(kCFBooleanTrue, to: UnsafeRawPointer.self))
+
+        guard let array = TISCreateInputSourceList(conditions, true) else {
+            return nil
+        }
+        guard let keyboards = array.takeRetainedValue() as? [TISInputSource] else {
+            return nil
+        }
+        return keyboards.sorted {
+            $0.localizedName < $1.localizedName
+        }
+    }
+}

--- a/Sources/InputMethodKit/EmojiInputController.swift
+++ b/Sources/InputMethodKit/EmojiInputController.swift
@@ -93,7 +93,7 @@ extension EmojiInputController /* IMKStateSetting*/ {
         guard let client = sender as? IMKTextInput else {
             return
         }
-        client.overrideKeyboard(withKeyboardNamed: "com.apple.keylayout.US")
+        client.overrideKeyboard(withKeyboardNamed: SettingStore().keyboardLayout())
     }
 
     override func deactivateServer(_ sender: Any) {
@@ -110,7 +110,7 @@ extension EmojiInputController /* IMKStateSetting*/ {
             return
         }
         directMode = value == "com.apple.inputmethod.Roman"
-        sender.overrideKeyboard(withKeyboardNamed: "com.apple.keylayout.US")
+        sender.overrideKeyboard(withKeyboardNamed: SettingStore().keyboardLayout())
     }
 }
 

--- a/Sources/Preferences/Preferences.swift
+++ b/Sources/Preferences/Preferences.swift
@@ -14,6 +14,7 @@ import ReactiveCocoa
 
 @objc(Preferences)
 public class Preferences: NSPreferencePane {
+    private let store: SettingStore = SettingStore()
     private lazy var keyboardLayouts: [TISInputSource]? = TISInputSource.keyboardLayouts()
 
     override public func mainViewDidLoad() {
@@ -23,6 +24,14 @@ public class Preferences: NSPreferencePane {
         let keyboard = NSPopUpButton() ※ {
             for layout in keyboardLayouts ?? [] {
                 $0.addItem(withTitle: layout.localizedName)
+            }
+            $0.reactive.selectedIndexes.observeValues {
+                if let layout = self.keyboardLayouts?[$0] {
+                    self.store.setKeyboardLayout(inputSourceID: layout.inputSourceID)
+                }
+            }
+            if let index = keyboardLayouts?.index(where: { $0.inputSourceID == store.keyboardLayout() }) {
+                $0.selectItem(at: index)
             }
         }
         let revisionLabel = NSTextField.label(text: "Revision:")  ※ {

--- a/Sources/Preferences/Preferences.swift
+++ b/Sources/Preferences/Preferences.swift
@@ -6,14 +6,26 @@
 //  Copyright © 2017 mzp. All rights reserved.
 //
 
+import CoreFoundation
 import Ikemen
 import NorthLayout
 import PreferencePanes
+import ReactiveCocoa
 
 @objc(Preferences)
 public class Preferences: NSPreferencePane {
+    private lazy var keyboardLayouts: [TISInputSource]? = TISInputSource.keyboardLayouts()
+
     override public func mainViewDidLoad() {
-        let revisionLabel = NSTextField.label(text: "Revision:") ※ {
+        let keyboardLabel = NSTextField.label(text: "Keybaord:") ※ {
+            $0.alignment = .right
+        }
+        let keyboard = NSPopUpButton() ※ {
+            for layout in keyboardLayouts ?? [] {
+                $0.addItem(withTitle: layout.localizedName)
+            }
+        }
+        let revisionLabel = NSTextField.label(text: "Revision:")  ※ {
             $0.alignment = .right
         }
         let revision = NSTextField.label(text: kRevision)
@@ -30,15 +42,18 @@ public class Preferences: NSPreferencePane {
                 "h": 16
             ],
             [
+                "keyboardLabel": keyboardLabel,
+                "keyboard": keyboard,
                 "revisionLabel": revisionLabel,
                 "revision": revision,
                 "builtDateLabel": builtDateLabel,
                 "builtDate": builtDate
             ]
         )
+        autolayout("H:|-p-[keyboardLabel(==w)]-m-[keyboard]-p-|")
         autolayout("H:|-p-[builtDateLabel(==w)]-m-[builtDate]-p-|")
         autolayout("H:|-p-[revisionLabel(==w)]-m-[revision]-p-|")
-        autolayout("V:|-p-[builtDateLabel(==h)]-m-[revisionLabel(==h)]|")
-        autolayout("V:|-p-[builtDate(==h)]-m-[revision(==h)]|")
+        autolayout("V:|-p-[keyboardLabel(==h)]-m-[builtDateLabel(==h)]-m-[revisionLabel(==h)]|")
+        autolayout("V:|-p-[keyboard(==h)]-m-[builtDate(==h)]-m-[revision(==h)]|")
     }
 }

--- a/Sources/Setting/SettingStore.swift
+++ b/Sources/Setting/SettingStore.swift
@@ -1,0 +1,37 @@
+//
+//  SettingStore.swift
+//  EmojiIM
+//
+//  Created by mzp on 2017/11/13.
+//  Copyright © 2017 mzp. All rights reserved.
+//
+import Cocoa
+
+internal class SettingStore {
+    private let kSuiteName: String = "jp.mzp.inputmethod.EmojiIM"
+
+    func setKeyboardLayout(inputSourceID: String) {
+        userDefaults?.set(inputSourceID, forKey: "keyboardLayout")
+        userDefaults?.synchronize()
+    }
+
+    func keyboardLayout() -> String {
+        return (userDefaults?.value(forKey: "keyboardLayout") as? String) ?? "com.apple.keylayout.US"
+    }
+
+    private var inSandbox: Bool {
+        return Bundle.main.bundleIdentifier == kSuiteName
+    }
+
+    private lazy var userDefaults: UserDefaults? = {
+        if inSandbox {
+            return UserDefaults.standard
+        } else {
+            return UserDefaults(suiteName: suiteName)
+        }
+    }()
+
+    private var suiteName: String {
+        return "\(NSHomeDirectory())/Library/Containers/\(kSuiteName)/Data/Library/Preferences/\(kSuiteName)"
+    }
+}


### PR DESCRIPTION
Add keyboard layout setting.

## 🤔 Share user defaults between preference pane and input method
Although modern application(including input method) lives in [sandbox](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AboutAppSandbox/AboutAppSandbox.html), input method preference pane is out of sandbox.

To access sandbox-ed user defaults from non-sandboxed app, add prefix for suite name. ([osx - How does OS X's defaults command get access to prefs of sandboxed apps? - Stack Overflow](https://stackoverflow.com/questions/20705279/how-does-os-xs-defaults-command-get-access-to-prefs-of-sandboxed-apps))

```swift
let suiteName = "/Users/mzp/Library/Containers/jp.mzp.inputmethod.EmojiIM/Data/Library/Preferences/jp.mzp.inputmethod.EmojiIM"
let userDefaults = UserDefaults(suiteName: suiteName)

// set value from non-sandboxed
userDefaults?.set("some value", forKey: "some-key")

// get value from non-sandboxed
userDefaults?.value(forKey: "some-key")
```

## ⌨️ Enumerate all keyboad layouts
To enumerate all keyboard layouts, use `TISCreateInputSourceList` of HIToolbox like this:

```swift
    class func keyboardLayouts() -> [TISInputSource]? {
        let conditions = CFDictionaryCreateMutable(nil, 2, nil, nil)
        CFDictionaryAddValue(conditions,
                             unsafeBitCast(kTISPropertyInputSourceType, to: UnsafeRawPointer.self),
                             unsafeBitCast(kTISTypeKeyboardLayout, to: UnsafeRawPointer.self))
        CFDictionaryAddValue(conditions,
                             unsafeBitCast(kTISPropertyInputSourceIsASCIICapable, to: UnsafeRawPointer.self),
                             unsafeBitCast(kCFBooleanTrue, to: UnsafeRawPointer.self))

        guard let array = TISCreateInputSourceList(conditions, true) else {
            return nil
        }
        guard let keyboards = array.takeRetainedValue() as? [TISInputSource] else {
            return nil
        }
        return keyboards.sorted {
            $0.localizedName < $1.localizedName
        }
    }
```

## :lipstick: Overwrite keyboard layout
To overwrite keyboard layout, use `overrideKeyboard` method of `IMKTextInput`.

```swift
    override func activateServer(_ sender: Any) {
        NSLog("%@", "\(#function)((\(sender))")

        guard let client = sender as? IMKTextInput else {
            return
        }
        client.overrideKeyboard(withKeyboardNamed: SettingStore().keyboardLayout())
    }
```