### PR TITLE
Permit read access to system preference from input method

### DIFF
--- a/Resources/EmojiIM/EmojiIM.entitlements
+++ b/Resources/EmojiIM/EmojiIM.entitlements
@@ -6,5 +6,7 @@
 	<true/>
 	<key>com.apple.security.temporary-exception.mach-register.global-name</key>
 	<string>jp.mzp.inputmethod.EmojiIM_Connection</string>
+	<key>com.apple.security.temporary-exception.shared-preference.read-only</key>
+	<string>jp.mzp.inputmethod.EmojiIM</string>
 </dict>
 </plist>

--- a/Sources/Setting/SettingStore.swift
+++ b/Sources/Setting/SettingStore.swift
@@ -27,11 +27,7 @@ internal class SettingStore {
         if inSandbox {
             return UserDefaults.standard
         } else {
-            return UserDefaults(suiteName: suiteName)
+            return UserDefaults(suiteName: kSuiteName)
         }
     }()
-
-    private var suiteName: String {
-        return "\(NSHomeDirectory())/Library/Containers/\(kSuiteName)/Data/Library/Preferences/\(kSuiteName)"
-    }
 }


### PR DESCRIPTION
Use app sandbox temporary exception to access shared preferences between input method and preference pane.

https://developer.apple.com/library/content/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/AppSandboxTemporaryExceptionEntitlements.html#//apple_ref/doc/uid/TP40011195-CH5-SW4