### PR TITLE
Enumerate all keyboard layouts

### DIFF
--- a/Sources/Extension/TISInputSource+Property.swift
+++ b/Sources/Extension/TISInputSource+Property.swift
@@ -19,6 +19,12 @@ extension TISInputSource {
             to: NSString.self) as String
     }
 
+    var scriptCode: Int? {
+        let r = TISGetInputSourceProperty(self, "TSMInputSourcePropertyScriptCode" as CFString)
+        let n = unsafeBitCast(r, to: NSInteger.self)
+        return n
+    }
+
     class func keyboardLayouts() -> [TISInputSource]? {
         let conditions = CFDictionaryCreateMutable(nil, 2, nil, nil)
         CFDictionaryAddValue(conditions,

--- a/Sources/Preferences/Preferences.swift
+++ b/Sources/Preferences/Preferences.swift
@@ -15,7 +15,10 @@ import ReactiveCocoa
 @objc(Preferences)
 public class Preferences: NSPreferencePane {
     private let store: SettingStore = SettingStore()
-    private lazy var keyboardLayouts: [TISInputSource]? = TISInputSource.keyboardLayouts()
+    private lazy var keyboardLayouts: [TISInputSource]? = TISInputSource.keyboardLayouts()?.filter {
+        // 39 means English keyboard layout
+        $0.scriptCode == 39
+    }
 
     override public func mainViewDidLoad() {
         let keyboardLabel = NSTextField.label(text: "Keybaord:") ※ {


### PR DESCRIPTION
InputMethods convert key events to text inputs.  The mapping from a hardware key to a key event is customizable at macOS system preference.

Although most of people uses QWERTY layout, some people like other layouts(e.g. Colemark, Dvorak). So, most of input method have a keyboard layout preference.

## ⌨️ Enumerate available keyboard layouts
HIToolbox of Carbon framework provides the function to enumerate keyboard layouts.  HIToolbox calls keyboard layouts and input methods as InputSource.

`TISCreateInputSourceList` returns input source matched with given conditions. To obtain keyboard layout, use condition: "input source type is keyboard layout and ascii-capable keyboard".

```swift
let conditions = CFDictionaryCreateMutable(nil, 2, nil, nil)
CFDictionaryAddValue(conditions,
                     unsafeBitCast(kTISPropertyInputSourceType, to: UnsafeRawPointer.self),
                     unsafeBitCast(kTISTypeKeyboardLayout, to: UnsafeRawPointer.self))
CFDictionaryAddValue(conditions,
                     unsafeBitCast(kTISPropertyInputSourceIsASCIICapable, to: UnsafeRawPointer.self),
                     unsafeBitCast(kCFBooleanTrue, to: UnsafeRawPointer.self))

guard let array = TISCreateInputSourceList(conditions, true) else {
    return nil
}
return array.takeRetainedValue() as? [TISInputSource]
```

The keyboard layout property is got by `TISGetInputSourceProperty`.

```swift
// get input source id
TISGetInputSourceProperty(inputSource, kTISPropertyInputSourceID)

// get layout name
TISGetInputSourceProperty(inputSource, kTISPropertyLocalizedName)
```

## 🙈 2 kind of keyboard layout
There are 2 kinds of ASCII-capable keyboard.

First is a keyboard which has same keys and another of qwerty layout. At macOS, these are English keyboards. 

Second is a keyboard which has special key(e.g. ù). These are non-English keyboards.

To distinguish of two, use `TSMInputSourcePropertyScriptCode`  property. This key is non-documented and I found it in JapaneseIM.

```swift
let r = TISGetInputSourceProperty(inputSource, "TSMInputSourcePropertyScriptCode" as CFString)
let n = unsafeBitCast(r, to: NSInteger.self)
return n == 39
```
